### PR TITLE
Debug hover over user defined types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed hovering over user defined types while debugging
+  ([#426](https://github.com/fortran-lang/vscode-fortran-support/issues/426))
 - Fixes linting regex to capture a wider spectrum of errors
   ([#295](https://github.com/krvajal/vscode-fortran-support/issues/295))
 - Fixes linter activation from `Disabled` to some compiler `X` without having


### PR DESCRIPTION
Fixes #426

We register a custom Evaluatable expression which
captures the entire variable from start until the correct `%`
where the cursor is located.