### PR TITLE
Added `ifx` linting support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added `ifx` support Intel's LLVM based compiler `ifx`
 - Added ability to rescan for linting include files.
 - Added GitHub Actions support for pre-Release builds
   ([#459](https://github.com/fortran-lang/vscode-fortran-support/issues/459))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,9 +59,4 @@ You can actively debug the extension by pressing <kbd>F5</kbd> with `Launch Exte
 👉 **Tip!** You don't need to stop and restart the development version of VS Code after each change. You can just execute `Reload Window` from the command palette in the
 VS Code window prefixed with `[Extension Development Host]`.
 
-
-
 https://user-images.githubusercontent.com/16143716/167411072-58a25378-13ad-41c5-bb20-2dacc8ad004a.mp4
-
-
-

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - GoTo/Peek implementation and Find/Peek references
 - Project-wide and Document symbol detection and Renaming
 - Native Language Server integration with [`fortls`](https://github.com/gnikit/fortls)
-- Linting support for `gfortran`, `flang` and `ifort`
+- Linting support for GCC's [`gfortran`](https://gcc.gnu.org/wiki/GFortran), and Intel's [`ifort`](https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html) and `ifx`
 - Debugger [C/C++ extension](https://github.com/Microsoft/vscode-cpptools)
 - Formatting with [findent](https://github.com/gnikit/findent-pypi) or [fprettify](https://github.com/pseewald/fprettify)
 - Code snippets (more can be defined by the user [see](https://code.visualstudio.com/docs/editor/userdefinedsnippets#_create-your-own-snippets))
@@ -60,7 +60,7 @@ Using incorrect type and rank as function argument
 
 ![alt](assets/lint-demo2.gif)
 
-| :memo: Note                                |
+| 📝️ Note                                   |
 | ------------------------------------------ |
 | Save your file to generate linting results |
 
@@ -70,7 +70,7 @@ Linting results can be improved by providing additional options to the compiler.
 
 You can control the include paths to be used by the linter with the `fortran.linter.includePaths` option.
 
-| :exclamation: Important                                                                                            |
+| ❗️ Important                                                                                                      |
 | ------------------------------------------------------------------------------------------------------------------ |
 | For the best linting results `linter.includePaths` should match the included paths for your project's compilation. |
 
@@ -80,7 +80,7 @@ You can control the include paths to be used by the linter with the `fortran.lin
 }
 ```
 
-| :exclamation: Important                                                          |
+| ❗️ Important                                                                    |
 | -------------------------------------------------------------------------------- |
 | If a glob pattern is used only directories matching the pattern will be included |
 
@@ -103,12 +103,12 @@ Default value is `-Wall` (or `-warn all` for ifort).
 
 ### Changing linting compiler
 
-By default, the linter used is `gfortran`, Intel's `ifort` and LLVM's `flang` are also supported.
+By default, the linter used is `gfortran`, Intel's `ifort` and Intel's LLVM based compiler `ifx` are also supported.
 One can use a different linter compiler via the option
 
 ```jsonc
 {
-  "fortran.linter.compiler": "ifort" | "gfortran" | "flang" | "Disabled"
+  "fortran.linter.compiler": "ifort" | "gfortran" | "ifx" | "Disabled"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -166,8 +166,8 @@
           "default": "gfortran",
           "enum": [
             "gfortran",
-            "flang",
             "ifort",
+            "ifx",
             "Disabled"
           ],
           "markdownDescription": "Compiler used for linting support."
@@ -275,7 +275,7 @@
         "fortran.fortls.maxLineLength": {
           "type": "number",
           "default": -1,
-          "markdownDescription": "Maximum line length. For `gfortran` and `flang` this also sets the linting compiler flag `-ffree-line-length-<n>` and `-ffixed-line-length-<n>`. Default value is `none`."
+          "markdownDescription": "Maximum line length. For `gfortran` this also sets the linting compiler flag `-ffree-line-length-<n>` and `-ffixed-line-length-<n>`. Default value is `none`."
         },
         "fortran.fortls.maxCommentLineLength": {
           "type": "number",

--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -142,6 +142,7 @@ export class FortranLintingProvider {
     let modout: string = config.get('linter.modOutput', '');
     let modFlag = '-J';
     switch (compiler) {
+      case 'ifx':
       case 'ifort':
         modFlag = '-module ';
         break;
@@ -240,7 +241,7 @@ export class FortranLintingProvider {
    * specified.
    * Attempts to match and resolve any internal variables, but no glob support.
    *
-   * @param compiler compiler name `gfortran`, `flang`, `ifort`
+   * @param compiler compiler name `gfortran`, `ifort`, `ifx`
    * @returns
    */
   private getLinterExtraArgs(compiler: string): string[] {
@@ -255,6 +256,7 @@ export class FortranLintingProvider {
         args = ['-Wall'];
         break;
 
+      case 'ifx':
       case 'ifort':
         args = ['-warn', 'all'];
         break;
@@ -269,7 +271,7 @@ export class FortranLintingProvider {
     // gfortran and flang have compiler flags for restricting the width of
     // the code.
     // You can always override by passing in the correct args as extraArgs
-    if (compiler !== 'ifort') {
+    if (compiler !== 'ifort' && compiler !== 'ifx') {
       const ln: number = config.get('fortls.maxLineLength');
       const lnStr: string = ln === -1 ? 'none' : ln.toString();
       args.push(`-ffree-line-length-${lnStr}`, `-ffixed-line-length-${lnStr}`);
@@ -339,6 +341,7 @@ export class FortranLintingProvider {
       case 'flang':
         break;
 
+      case 'ifx':
       case 'ifort':
         for (const m of matches) {
           const g = m.groups;
@@ -420,6 +423,7 @@ export class FortranLintingProvider {
                           failing line of code
        ----------------------^
        */
+      case 'ifx':
       case 'ifort':
         // see https://regex101.com/r/GZ0Lzz/2
         return /^(?<fname>(?:\w:\\)?.*)\((?<ln>\d+)\):\s*(?:#(?:(?<sev2>\w*):\s*(?<msg2>.*$))|(?<sev1>\w*)\s*(?<msg1>.*$)(?:\s*.*\s*)(?<cn>-*\^))/gm;
@@ -447,6 +451,7 @@ export class FortranLintingProvider {
 
       // ifort theoretically supports fsyntax-only too but I had trouble
       // getting it to work on my machine
+      case 'ifx':
       case 'ifort':
         return ['-syntax-only', '-fpp'];
 


### PR DESCRIPTION
Removed `flang` references from README and package.json
since `flang` is difficult to isntall for new VS code users.
Will add flang if there is a request.