### PR TITLE
Removes need for matching begin-end scope names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Changed need for matching begin-end scope names, in the following constructs:
+  Functions, Modules, Programs, Module Procedures, Subroutines, Submodules.
+  For a more detailed explanation as to why see the issue
+  ([#278](https://github.com/fortran-lang/vscode-fortran-support/issues/278))
 - Rewrote README to include links to fortran-lang and other projects
   ([#485](https://github.com/fortran-lang/vscode-fortran-support/issues/485))
   ([#501](https://github.com/fortran-lang/vscode-fortran-support/issues/501))

--- a/syntaxes/fortran_free-form.tmLanguage.json
+++ b/syntaxes/fortran_free-form.tmLanguage.json
@@ -4060,7 +4060,7 @@
                   "name": "entity.name.function.fortran"
                 }
               },
-              "end": "(?ix)\\s*\\b(?:(end\\s*function)(?:\\s+(\\1))?|(end))\\b \\s*([^;!\\n]+)?(?=[;!\\n])",
+              "end": "(?ix)\\s*\\b(?:(end\\s*function)(?:\\s+([a-z_]\\w*))?|(end))\\b \\s*([^;!\\n]+)?(?=[;!\\n])",
               "endCaptures": {
                 "1": {
                   "name": "keyword.other.endfunction.fortran"
@@ -4148,7 +4148,7 @@
               "name": "entity.name.class.module.fortran"
             }
           },
-          "end": "(?ix)\\b(?:(end\\s*module)(?:\\s+(\\1))?|(end))\\b \\s*([^;!\\n]+)?(?=[;!\\n])",
+          "end": "(?ix)\\b(?:(end\\s*module)(?:\\s+([a-z_]\\w*))?|(end))\\b \\s*([^;!\\n]+)?(?=[;!\\n])",
           "endCaptures": {
             "1": {
               "name": "keyword.other.endmodule.fortran"
@@ -4218,7 +4218,7 @@
               "name": "entity.name.program.fortran"
             }
           },
-          "end": "(?ix)\\b(?:(end\\s*program)(?:\\s+(\\1))?|(end))\\b\\s*([^;!\\n]+)?(?=[;!\\n])",
+          "end": "(?ix)\\b(?:(end\\s*program)(?:\\s+([a-z_]\\w*))?|(end))\\b\\s*([^;!\\n]+)?(?=[;!\\n])",
           "endCaptures": {
             "1": {
               "name": "keyword.control.endprogram.fortran"
@@ -4289,7 +4289,7 @@
                   "name": "entity.name.function.procedure.fortran"
                 }
               },
-              "end": "(?ix)\\s*\\b(?:(end\\s*procedure)(?:\\s+(\\1))?|(end))\\b \\s*([^;!\\n]+)?(?=[;!\\n])",
+              "end": "(?ix)\\s*\\b(?:(end\\s*procedure)(?:\\s+([a-z_]\\w*))?|(end))\\b \\s*([^;!\\n]+)?(?=[;!\\n])",
               "endCaptures": {
                 "1": {
                   "name": "keyword.other.endprocedure.fortran"
@@ -4395,7 +4395,7 @@
                   "name": "entity.name.function.subroutine.fortran"
                 }
               },
-              "end": "(?ix)\\b(?:(end\\s*subroutine)(?:\\s+(\\1))?|(end))\\b \\s*([^;!\\n]+)?(?=[;!\\n])",
+              "end": "(?ix)\\b(?:(end\\s*subroutine)(?:\\s+([a-z_]\\w*))?|(end))\\b \\s*([^;!\\n]+)?(?=[;!\\n])",
               "endCaptures": {
                 "1": {
                   "name": "keyword.other.endsubroutine.fortran"
@@ -4493,7 +4493,7 @@
               "name": "entity.name.module.submodule.fortran"
             }
           },
-          "end": "(?ix)\\s*\\b(?:(end\\s*submodule)(?:\\s+(\\1))?|(end))\\b \\s*([^;!\\n]+)?(?=[;!\\n])",
+          "end": "(?ix)\\s*\\b(?:(end\\s*submodule)(?:\\s+([a-z_]\\w*))?|(end))\\b \\s*([^;!\\n]+)?(?=[;!\\n])",
           "endCaptures": {
             "1": {
               "name": "keyword.other.endsubmodule.fortran"

--- a/test/resources/pp_in_func.f90
+++ b/test/resources/pp_in_func.f90
@@ -1,0 +1,121 @@
+! Out of order nested function/subroutine definitions such as in the case
+! of preprocessing directives, where the inner scope is not the scope that closes
+! first, yield invalid.error syntax highlighting because we attempt to match
+! the name from the begin REGEX to the end REGEX match i.e. \\1
+! This can be circumvented by matching a word character instead [a-z_]\\w*
+! Obviously this is not going to highlight when the wrong name is used to
+! close a scope, but the linter should solve that
+
+!
+subroutine blasmul_mm()
+   interface
+#ifdef DOUBLEP
+      SUBROUTINE DGEMM ( )
+#else
+      SUBROUTINE SGEMM (  )
+#endif
+
+#ifdef DOUBLEP
+      END SUBROUTINE DGEMM
+#else
+      END SUBROUTINE SGEMM
+#endif
+   end interface
+
+end subroutine blasmul_mm
+
+! This would work with the previous definition of the end REGEX because the scopes
+! close in the order that they open
+subroutine blasmul_mm()
+   interface
+#ifdef DOUBLEP
+      SUBROUTINE DGEMM ( )
+#else
+      SUBROUTINE SGEMM (  )
+#endif
+
+#ifndef DOUBLEP
+      END SUBROUTINE SGEMM
+#else
+      END SUBROUTINE DGEMM
+#endif
+   end interface
+
+end subroutine blasmul_mm
+
+REAL FUNCTION blasmul_mm() RESULT(VAL)
+   interface
+#ifdef DOUBLEP
+      FUNCTION DGEMM ( )
+#else
+      FUNCTION SGEMM (  )
+#endif
+
+#ifdef DOUBLEP
+      END FUNCTION DGEMM
+#else
+      END FUNCTION SGEMM
+#endif
+   end interface
+
+END FUNCTION blasmul_mm
+
+MODULE blasmul_mm
+#ifdef DOUBLEP
+   MODULE DGEMM
+#else
+   MODULE SGEMM
+#endif
+
+#ifdef DOUBLEP
+   END MODULE DGEMM
+#else
+   END MODULE SGEMM
+#endif
+
+end MODULE blasmul_mm
+
+SUBMODULE (name) blasmul_mm
+#ifdef DOUBLEP
+   SUBMODULE (name) DGEMM
+#else
+   SUBMODULE (name) SGEMM
+#endif
+
+#ifdef DOUBLEP
+   END SUBMODULE DGEMM
+#else
+   END SUBMODULE SGEMM
+#endif
+
+end SUBMODULE blasmul_mm
+
+PROGRAM blasmul_mm
+#ifdef DOUBLEP
+   PROGRAM DGEMM
+#else
+   PROGRAM SGEMM
+#endif
+
+#ifdef DOUBLEP
+   END PROGRAM DGEMM
+#else
+   END PROGRAM SGEMM
+#endif
+
+end PROGRAM blasmul_mm
+
+MODULE PROCEDURE blasmul_mm
+#ifdef DOUBLEP
+MODULE PROCEDURE DGEMM
+#else
+MODULE PROCEDURE SGEMM
+#endif
+
+#ifdef DOUBLEP
+END PROCEDURE DGEMM
+#else
+END PROCEDURE SGEMM
+#endif
+
+end PROCEDURE blasmul_mm

--- a/test/resources/pp_in_func.f90.snap
+++ b/test/resources/pp_in_func.f90.snap
@@ -1,0 +1,450 @@
+>! Out of order nested function/subroutine definitions such as in the case
+#^ source.fortran.free comment.line.fortran
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.fortran.free comment.line.fortran
+>! of preprocessing directives, where the inner scope is not the scope that closes
+#^ source.fortran.free comment.line.fortran
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.fortran.free comment.line.fortran
+>! first, yield invalid.error syntax highlighting because we attempt to match
+#^ source.fortran.free comment.line.fortran
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.fortran.free comment.line.fortran
+>! the name from the begin REGEX to the end REGEX match i.e. \\1
+#^ source.fortran.free comment.line.fortran
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.fortran.free comment.line.fortran
+>! This can be circumvented by matching a word character instead [a-z_]\\w*
+#^ source.fortran.free comment.line.fortran
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.fortran.free comment.line.fortran
+>! Obviously this is not going to highlight when the wrong name is used to
+#^ source.fortran.free comment.line.fortran
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.fortran.free comment.line.fortran
+>! close a scope, but the linter should solve that
+#^ source.fortran.free comment.line.fortran
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.fortran.free comment.line.fortran
+>
+>!
+#^ source.fortran.free comment.line.fortran
+>subroutine blasmul_mm()
+#^^^^^^^^^^ source.fortran.free meta.subroutine.fortran keyword.other.subroutine.fortran
+#          ^ source.fortran.free meta.subroutine.fortran
+#           ^^^^^^^^^^ source.fortran.free meta.subroutine.fortran entity.name.function.subroutine.fortran
+#                     ^ source.fortran.free meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list punctuation.definition.parameters.begin.fortran
+#                      ^ source.fortran.free meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list punctuation.definition.parameters.end.fortran
+>   interface
+#^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran
+#   ^^^^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran keyword.control.interface.fortran
+>#ifdef DOUBLEP
+#^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.preprocessor keyword.control.preprocessor.ifdef.fortran
+#      ^^^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.preprocessor
+>      SUBROUTINE DGEMM ( )
+#^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.attribute-list.subroutine.fortran
+#      ^^^^^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran keyword.other.subroutine.fortran
+#                ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran
+#                 ^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran entity.name.function.subroutine.fortran
+#                      ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list
+#                       ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list punctuation.definition.parameters.begin.fortran
+#                        ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list
+#                         ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list punctuation.definition.parameters.end.fortran
+>#else
+#^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.preprocessor keyword.control.preprocessor.else.fortran
+>      SUBROUTINE SGEMM (  )
+#^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.attribute-list.subroutine.fortran
+#      ^^^^^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran keyword.other.subroutine.fortran
+#                ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran
+#                 ^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran entity.name.function.subroutine.fortran
+#                      ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list
+#                       ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list punctuation.definition.parameters.begin.fortran
+#                        ^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list
+#                          ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list punctuation.definition.parameters.end.fortran
+>#endif
+#^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.preprocessor keyword.control.preprocessor.endif.fortran
+>
+>#ifdef DOUBLEP
+#^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.preprocessor keyword.control.preprocessor.ifdef.fortran
+#      ^^^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.preprocessor
+>      END SUBROUTINE DGEMM
+#^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran
+#      ^^^^^^^^^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran keyword.other.endsubroutine.fortran
+#                    ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran
+#                     ^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran entity.name.function.subroutine.fortran
+>#else
+#^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.preprocessor keyword.control.preprocessor.else.fortran
+>      END SUBROUTINE SGEMM
+#^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran
+#      ^^^^^^^^^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran keyword.other.endsubroutine.fortran
+#                    ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran
+#                     ^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran entity.name.function.subroutine.fortran
+>#endif
+#^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.preprocessor keyword.control.preprocessor.endif.fortran
+>   end interface
+#^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran
+#   ^^^^^^^^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran keyword.control.endinterface.fortran.modern
+>
+>end subroutine blasmul_mm
+#^^^^^^^^^^^^^^ source.fortran.free meta.subroutine.fortran keyword.other.endsubroutine.fortran
+#              ^ source.fortran.free meta.subroutine.fortran
+#               ^^^^^^^^^^ source.fortran.free meta.subroutine.fortran entity.name.function.subroutine.fortran
+>
+>! This would work with the previous definition of the end REGEX because the scopes
+#^ source.fortran.free comment.line.fortran
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.fortran.free comment.line.fortran
+>! close in the order that they open
+#^ source.fortran.free comment.line.fortran
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.fortran.free comment.line.fortran
+>subroutine blasmul_mm()
+#^^^^^^^^^^ source.fortran.free meta.subroutine.fortran keyword.other.subroutine.fortran
+#          ^ source.fortran.free meta.subroutine.fortran
+#           ^^^^^^^^^^ source.fortran.free meta.subroutine.fortran entity.name.function.subroutine.fortran
+#                     ^ source.fortran.free meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list punctuation.definition.parameters.begin.fortran
+#                      ^ source.fortran.free meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list punctuation.definition.parameters.end.fortran
+>   interface
+#^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran
+#   ^^^^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran keyword.control.interface.fortran
+>#ifdef DOUBLEP
+#^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.preprocessor keyword.control.preprocessor.ifdef.fortran
+#      ^^^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.preprocessor
+>      SUBROUTINE DGEMM ( )
+#^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.attribute-list.subroutine.fortran
+#      ^^^^^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran keyword.other.subroutine.fortran
+#                ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran
+#                 ^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran entity.name.function.subroutine.fortran
+#                      ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list
+#                       ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list punctuation.definition.parameters.begin.fortran
+#                        ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list
+#                         ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list punctuation.definition.parameters.end.fortran
+>#else
+#^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.preprocessor keyword.control.preprocessor.else.fortran
+>      SUBROUTINE SGEMM (  )
+#^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.attribute-list.subroutine.fortran
+#      ^^^^^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran keyword.other.subroutine.fortran
+#                ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran
+#                 ^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran entity.name.function.subroutine.fortran
+#                      ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list
+#                       ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list punctuation.definition.parameters.begin.fortran
+#                        ^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list
+#                          ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.first-line.fortran meta.dummy-variable-list punctuation.definition.parameters.end.fortran
+>#endif
+#^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.preprocessor keyword.control.preprocessor.endif.fortran
+>
+>#ifndef DOUBLEP
+#^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.preprocessor keyword.control.preprocessor.ifndef.fortran
+#       ^^^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.preprocessor
+>      END SUBROUTINE SGEMM
+#^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran
+#      ^^^^^^^^^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran keyword.other.endsubroutine.fortran
+#                    ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran
+#                     ^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.subroutine.fortran entity.name.function.subroutine.fortran
+>#else
+#^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.preprocessor keyword.control.preprocessor.else.fortran
+>      END SUBROUTINE DGEMM
+#^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran meta.block.specification.subroutine.fortran
+#      ^^^^^^^^^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran keyword.other.endsubroutine.fortran
+#                    ^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran
+#                     ^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.subroutine.fortran entity.name.function.subroutine.fortran
+>#endif
+#^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran meta.preprocessor keyword.control.preprocessor.endif.fortran
+>   end interface
+#^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran
+#   ^^^^^^^^^^^^^ source.fortran.free meta.subroutine.fortran meta.block.specification.subroutine.fortran meta.interface.explicit.fortran keyword.control.endinterface.fortran.modern
+>
+>end subroutine blasmul_mm
+#^^^^^^^^^^^^^^ source.fortran.free meta.subroutine.fortran keyword.other.endsubroutine.fortran
+#              ^ source.fortran.free meta.subroutine.fortran
+#               ^^^^^^^^^^ source.fortran.free meta.subroutine.fortran entity.name.function.subroutine.fortran
+>
+>REAL FUNCTION blasmul_mm() RESULT(VAL)
+#^^^^ source.fortran.free meta.function.fortran meta.attribute-list.function.fortran storage.type.real.fortran
+#    ^ source.fortran.free meta.function.fortran meta.attribute-list.function.fortran
+#     ^^^^^^^^ source.fortran.free meta.function.fortran keyword.other.function.fortran
+#             ^ source.fortran.free meta.function.fortran
+#              ^^^^^^^^^^ source.fortran.free meta.function.fortran entity.name.function.fortran
+#                        ^ source.fortran.free meta.function.fortran meta.function.first-line.fortran meta.dummy-variable-list punctuation.definition.parameters.begin.fortran
+#                         ^ source.fortran.free meta.function.fortran meta.function.first-line.fortran meta.dummy-variable-list punctuation.definition.parameters.end.fortran
+#                          ^ source.fortran.free meta.function.fortran meta.function.first-line.fortran
+#                           ^^^^^^ source.fortran.free meta.function.fortran meta.function.first-line.fortran keyword.control.result.fortran
+#                                 ^ source.fortran.free meta.function.fortran meta.function.first-line.fortran punctuation.parentheses.left.fortran
+#                                  ^^^ source.fortran.free meta.function.fortran meta.function.first-line.fortran variable.parameter.fortran
+#                                     ^ source.fortran.free meta.function.fortran meta.function.first-line.fortran punctuation.parentheses.right.fortran
+>   interface
+#^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran
+#   ^^^^^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran keyword.control.interface.fortran
+>#ifdef DOUBLEP
+#^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.preprocessor keyword.control.preprocessor.ifdef.fortran
+#      ^^^^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.preprocessor
+>      FUNCTION DGEMM ( )
+#^^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.attribute-list.function.fortran
+#      ^^^^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran keyword.other.function.fortran
+#              ^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran
+#               ^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran entity.name.function.fortran
+#                    ^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.function.first-line.fortran meta.dummy-variable-list
+#                     ^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.function.first-line.fortran meta.dummy-variable-list punctuation.definition.parameters.begin.fortran
+#                      ^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.function.first-line.fortran meta.dummy-variable-list
+#                       ^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.function.first-line.fortran meta.dummy-variable-list punctuation.definition.parameters.end.fortran
+>#else
+#^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.preprocessor keyword.control.preprocessor.else.fortran
+>      FUNCTION SGEMM (  )
+#^^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.function.fortran meta.attribute-list.function.fortran
+#      ^^^^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.function.fortran keyword.other.function.fortran
+#              ^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.function.fortran
+#               ^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.function.fortran entity.name.function.fortran
+#                    ^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.function.fortran meta.function.first-line.fortran meta.dummy-variable-list
+#                     ^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.function.fortran meta.function.first-line.fortran meta.dummy-variable-list punctuation.definition.parameters.begin.fortran
+#                      ^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.function.fortran meta.function.first-line.fortran meta.dummy-variable-list
+#                        ^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.function.fortran meta.function.first-line.fortran meta.dummy-variable-list punctuation.definition.parameters.end.fortran
+>#endif
+#^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.function.fortran meta.block.specification.function.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.function.fortran meta.block.specification.function.fortran meta.preprocessor keyword.control.preprocessor.endif.fortran
+>
+>#ifdef DOUBLEP
+#^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.function.fortran meta.block.specification.function.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.function.fortran meta.block.specification.function.fortran meta.preprocessor keyword.control.preprocessor.ifdef.fortran
+#      ^^^^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.function.fortran meta.block.specification.function.fortran meta.preprocessor
+>      END FUNCTION DGEMM
+#^^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.function.fortran meta.block.specification.function.fortran
+#      ^^^^^^^^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.function.fortran keyword.other.endfunction.fortran
+#                  ^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.function.fortran
+#                   ^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.function.fortran entity.name.function.fortran
+>#else
+#^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran meta.preprocessor keyword.control.preprocessor.else.fortran
+>      END FUNCTION SGEMM
+#^^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran meta.block.specification.function.fortran
+#      ^^^^^^^^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran keyword.other.endfunction.fortran
+#                  ^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran
+#                   ^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.function.fortran entity.name.function.fortran
+>#endif
+#^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran meta.preprocessor keyword.control.preprocessor.endif.fortran
+>   end interface
+#^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran
+#   ^^^^^^^^^^^^^ source.fortran.free meta.function.fortran meta.block.specification.function.fortran meta.interface.explicit.fortran keyword.control.endinterface.fortran.modern
+>
+>END FUNCTION blasmul_mm
+#^^^^^^^^^^^^ source.fortran.free meta.function.fortran keyword.other.endfunction.fortran
+#            ^ source.fortran.free meta.function.fortran
+#             ^^^^^^^^^^ source.fortran.free meta.function.fortran entity.name.function.fortran
+>
+>MODULE blasmul_mm
+#^^^^^^ source.fortran.free meta.module.fortran keyword.other.program.fortran
+#      ^ source.fortran.free meta.module.fortran
+#       ^^^^^^^^^^ source.fortran.free meta.module.fortran entity.name.class.module.fortran
+>#ifdef DOUBLEP
+#^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.preprocessor keyword.control.preprocessor.ifdef.fortran
+#      ^^^^^^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.preprocessor
+>   MODULE DGEMM
+#^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran
+#   ^^^^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran keyword.other.program.fortran
+#         ^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran
+#          ^^^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran entity.name.class.module.fortran
+>#else
+#^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.preprocessor keyword.control.preprocessor.else.fortran
+>   MODULE SGEMM
+#^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran
+#   ^^^^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.module.fortran keyword.other.program.fortran
+#         ^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.module.fortran
+#          ^^^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.module.fortran entity.name.class.module.fortran
+>#endif
+#^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.preprocessor keyword.control.preprocessor.endif.fortran
+>
+>#ifdef DOUBLEP
+#^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.preprocessor keyword.control.preprocessor.ifdef.fortran
+#      ^^^^^^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.preprocessor
+>   END MODULE DGEMM
+#^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran
+#   ^^^^^^^^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.module.fortran keyword.other.endmodule.fortran
+#             ^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.module.fortran
+#              ^^^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.module.fortran entity.name.class.module.fortran
+>#else
+#^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran meta.preprocessor keyword.control.preprocessor.else.fortran
+>   END MODULE SGEMM
+#^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran meta.block.specification.module.fortran
+#   ^^^^^^^^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran keyword.other.endmodule.fortran
+#             ^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran
+#              ^^^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.module.fortran entity.name.class.module.fortran
+>#endif
+#^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.module.fortran meta.block.specification.module.fortran meta.preprocessor keyword.control.preprocessor.endif.fortran
+>
+>end MODULE blasmul_mm
+#^^^^^^^^^^ source.fortran.free meta.module.fortran keyword.other.endmodule.fortran
+#          ^ source.fortran.free meta.module.fortran
+#           ^^^^^^^^^^ source.fortran.free meta.module.fortran entity.name.class.module.fortran
+>
+>SUBMODULE (name) blasmul_mm
+#^^^^^^^^^ source.fortran.free meta.submodule.fortran keyword.other.submodule.fortran
+#         ^ source.fortran.free meta.submodule.fortran
+#          ^ source.fortran.free meta.submodule.fortran punctuation.parentheses.left.fortran
+#           ^^^^ source.fortran.free meta.submodule.fortran entity.name.class.submodule.fortran
+#               ^ source.fortran.free meta.submodule.fortran punctuation.parentheses.left.fortran
+#                ^ source.fortran.free meta.submodule.fortran
+#                 ^^^^^^^^^^ source.fortran.free meta.submodule.fortran entity.name.module.submodule.fortran
+>#ifdef DOUBLEP
+#^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.preprocessor keyword.control.preprocessor.ifdef.fortran
+#      ^^^^^^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.preprocessor
+>   SUBMODULE (name) DGEMM
+#^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran
+#   ^^^^^^^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran keyword.other.submodule.fortran
+#            ^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran
+#             ^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran punctuation.parentheses.left.fortran
+#              ^^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran entity.name.class.submodule.fortran
+#                  ^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran punctuation.parentheses.left.fortran
+#                   ^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran
+#                    ^^^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran entity.name.module.submodule.fortran
+>#else
+#^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.preprocessor keyword.control.preprocessor.else.fortran
+>   SUBMODULE (name) SGEMM
+#^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran
+#   ^^^^^^^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran keyword.other.submodule.fortran
+#            ^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran
+#             ^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran punctuation.parentheses.left.fortran
+#              ^^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran entity.name.class.submodule.fortran
+#                  ^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran punctuation.parentheses.left.fortran
+#                   ^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran
+#                    ^^^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran entity.name.module.submodule.fortran
+>#endif
+#^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.preprocessor keyword.control.preprocessor.endif.fortran
+>
+>#ifdef DOUBLEP
+#^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.preprocessor keyword.control.preprocessor.ifdef.fortran
+#      ^^^^^^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.preprocessor
+>   END SUBMODULE DGEMM
+#^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran
+#   ^^^^^^^^^^^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran keyword.other.endsubmodule.fortran
+#                ^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran
+#                 ^^^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran entity.name.module.submodule.fortran
+>#else
+#^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran meta.preprocessor keyword.control.preprocessor.else.fortran
+>   END SUBMODULE SGEMM
+#^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran meta.block.specification.submodule.fortran
+#   ^^^^^^^^^^^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran keyword.other.endsubmodule.fortran
+#                ^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran
+#                 ^^^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.submodule.fortran entity.name.module.submodule.fortran
+>#endif
+#^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.submodule.fortran meta.block.specification.submodule.fortran meta.preprocessor keyword.control.preprocessor.endif.fortran
+>
+>end SUBMODULE blasmul_mm
+#^^^^^^^^^^^^^ source.fortran.free meta.submodule.fortran keyword.other.endsubmodule.fortran
+#             ^ source.fortran.free meta.submodule.fortran
+#              ^^^^^^^^^^ source.fortran.free meta.submodule.fortran entity.name.module.submodule.fortran
+>
+>PROGRAM blasmul_mm
+#^^^^^^^ source.fortran.free meta.program.fortran keyword.control.program.fortran
+#       ^ source.fortran.free meta.program.fortran
+#        ^^^^^^^^^^ source.fortran.free meta.program.fortran entity.name.program.fortran
+>#ifdef DOUBLEP
+#^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.preprocessor keyword.control.preprocessor.ifdef.fortran
+#      ^^^^^^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.preprocessor
+>   PROGRAM DGEMM
+#^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran
+#   ^^^^^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran keyword.control.program.fortran
+#          ^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran
+#           ^^^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran entity.name.program.fortran
+>#else
+#^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.preprocessor keyword.control.preprocessor.else.fortran
+>   PROGRAM SGEMM
+#^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran
+#   ^^^^^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.program.fortran keyword.control.program.fortran
+#          ^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.program.fortran
+#           ^^^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.program.fortran entity.name.program.fortran
+>#endif
+#^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.preprocessor keyword.control.preprocessor.endif.fortran
+>
+>#ifdef DOUBLEP
+#^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.preprocessor keyword.control.preprocessor.ifdef.fortran
+#      ^^^^^^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.preprocessor
+>   END PROGRAM DGEMM
+#^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran
+#   ^^^^^^^^^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.program.fortran keyword.control.endprogram.fortran
+#              ^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.program.fortran
+#               ^^^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.program.fortran entity.name.program.fortran
+>#else
+#^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran meta.preprocessor keyword.control.preprocessor.else.fortran
+>   END PROGRAM SGEMM
+#^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran meta.block.specification.program.fortran
+#   ^^^^^^^^^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran keyword.control.endprogram.fortran
+#              ^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran
+#               ^^^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.program.fortran entity.name.program.fortran
+>#endif
+#^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.program.fortran meta.block.specification.program.fortran meta.preprocessor keyword.control.preprocessor.endif.fortran
+>
+>end PROGRAM blasmul_mm
+#^^^^^^^^^^^ source.fortran.free meta.program.fortran keyword.control.endprogram.fortran
+#           ^ source.fortran.free meta.program.fortran
+#            ^^^^^^^^^^ source.fortran.free meta.program.fortran entity.name.program.fortran
+>
+>MODULE PROCEDURE blasmul_mm
+#^^^^^^^^^^^^^^^^ source.fortran.free meta.procedure.fortran keyword.other.procedure.fortran
+#                ^ source.fortran.free meta.procedure.fortran
+#                 ^^^^^^^^^^ source.fortran.free meta.procedure.fortran entity.name.function.procedure.fortran
+>#ifdef DOUBLEP
+#^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.preprocessor keyword.control.preprocessor.ifdef.fortran
+#      ^^^^^^^^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.preprocessor
+>MODULE PROCEDURE DGEMM
+#^^^^^^^^^^^^^^^^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran keyword.other.procedure.fortran
+#                ^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran
+#                 ^^^^^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran entity.name.function.procedure.fortran
+>#else
+#^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.preprocessor keyword.control.preprocessor.else.fortran
+>MODULE PROCEDURE SGEMM
+#^^^^^^^^^^^^^^^^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran keyword.other.procedure.fortran
+#                ^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran
+#                 ^^^^^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran entity.name.function.procedure.fortran
+>#endif
+#^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.preprocessor keyword.control.preprocessor.endif.fortran
+>
+>#ifdef DOUBLEP
+#^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.preprocessor keyword.control.preprocessor.ifdef.fortran
+#      ^^^^^^^^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.preprocessor
+>END PROCEDURE DGEMM
+#^^^^^^^^^^^^^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran keyword.other.endprocedure.fortran
+#             ^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran
+#              ^^^^^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran entity.name.function.procedure.fortran
+>#else
+#^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran meta.block.specification.procedure.fortran meta.preprocessor keyword.control.preprocessor.else.fortran
+>END PROCEDURE SGEMM
+#^^^^^^^^^^^^^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran keyword.other.endprocedure.fortran
+#             ^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran
+#              ^^^^^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.procedure.fortran entity.name.function.procedure.fortran
+>#endif
+#^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.preprocessor keyword.control.preprocessor.indicator.fortran
+# ^^^^^ source.fortran.free meta.procedure.fortran meta.block.specification.procedure.fortran meta.preprocessor keyword.control.preprocessor.endif.fortran
+>
+>end PROCEDURE blasmul_mm
+#^^^^^^^^^^^^^ source.fortran.free meta.procedure.fortran keyword.other.endprocedure.fortran
+#             ^ source.fortran.free meta.procedure.fortran
+#              ^^^^^^^^^^ source.fortran.free meta.procedure.fortran entity.name.function.procedure.fortran
+>


### PR DESCRIPTION
Removes need for matching begin-end scope names

Previously nested scopes had to be closed in the reverse order than they
were opened e.g.

```f90
subroutine scope_1()
    subroutine scope_2()
    subroutine scope_3()
    end subroutine scope_3
    end subroutine scope_2
end subroutine scope_1
```

However with preprocessor conditionals that would be an issue since

```f90
subroutine scope_1()
#ifdef DEF
    subroutine scope_2()
#else
    subroutine scope_3()
#endif

#ifdef DEF
    end subroutine scope_2()
#else
    end subroutine scope_3()
#endif
end subroutine scope_1
```

`scope_2` and `scope_3`  would be in the same level on the AST, so it is
no longer valid to expect `scope_3` to close before `scope_2`.

The solution to this is removing the strict requirement for scopes to
have matching begin-end names from the regex. The type of scopes
where this requirement is removed are:

- Functions
- Modules
- Programs
- Module Procedures
- Subroutines
- Submodules

Fixes Erroneous syntax highlighting with subroutine names and preprocessor conditionals #278