### PR TITLE
[BUG] `linter.modOutput` not working for Intel compilers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Changed Free and Fixed Form language aliases. `Fortran` is now associated with `FortranFreeForm`
   ([#536](https://github.com/fortran-lang/vscode-fortran-support/issues/536))
 
+### Fixed
+
+- Fixed `linter.modOutput` not working with Intel Fortran Compilers
+  ([#538](https://github.com/fortran-lang/vscode-fortran-support/issues/538))
+
 ## [3.1.0]
 
 ### Changed

--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -122,7 +122,7 @@ export class FortranLintingProvider {
     const args = [
       ...this.getMandatoryLinterArgs(this.compiler),
       ...this.getLinterExtraArgs(this.compiler),
-      this.getModOutputDir(this.compiler),
+      ...this.getModOutputDir(this.compiler),
     ];
     const includePaths = this.getIncludePaths();
 
@@ -138,14 +138,14 @@ export class FortranLintingProvider {
     return argList.map(arg => arg.trim()).filter(arg => arg !== '');
   }
 
-  private getModOutputDir(compiler: string): string {
+  private getModOutputDir(compiler: string): string[] {
     const config = vscode.workspace.getConfiguration('fortran');
     let modout: string = config.get('linter.modOutput', '');
     let modFlag = '-J';
     switch (compiler) {
       case 'ifx':
       case 'ifort':
-        modFlag = '-module ';
+        modFlag = '-module';
         break;
 
       default:
@@ -153,10 +153,10 @@ export class FortranLintingProvider {
         break;
     }
     if (modout) {
-      modout = modFlag + resolveVariables(modout);
-      this.logger.logInfo(`Linter.moduleOutput: ${modout}`);
+      modout = resolveVariables(modout);
+      this.logger.logInfo(`Linter.moduleOutput: ${modFlag} ${modout}`);
     }
-    return modout;
+    return [modFlag, modout];
   }
 
   /**


### PR DESCRIPTION
Fixes #538