### PR TITLE
feat: Gfortran v11+enhanced linting support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added support for enhanced `gfotran` v11+ diagnostics using `-fdiagnostics-plain-output`
+  ([#523](https://github.com/fortran-lang/vscode-fortran-support/issues/523))
 - Added language icons for Free and Fixed form Fortran
   ([#612](https://github.com/fortran-lang/vscode-fortran-support/issues/612))
 - Added capability for linter options to update automatically when settings change

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "fast-glob": "^3.2.11",
         "glob": "^8.0.3",
+        "semver": "^7.3.7",
         "vscode-languageclient": "^8.0.2",
         "which": "^2.0.2"
       },
@@ -18,6 +19,7 @@
         "@types/glob": "^7.2.0",
         "@types/mocha": "^9.1.0",
         "@types/node": "^16.11.39",
+        "@types/semver": "^7.3.12",
         "@types/vscode": "^1.63.0",
         "@types/which": "^2.0.1",
         "@typescript-eslint/eslint-plugin": "^5.33.1",
@@ -277,6 +279,12 @@
       "version": "16.11.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.39.tgz",
       "integrity": "sha512-K0MsdV42vPwm9L6UwhIxMAOmcvH/1OoVkZyCgEtVu4Wx7sElGloy/W7kMBNe/oJ7V/jW9BVt1F6RahH6e7tPXw==",
+      "dev": true
+    },
+    "node_modules/@types/semver": {
+      "version": "7.3.12",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
+      "integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
       "dev": true
     },
     "node_modules/@types/vscode": {
@@ -5489,6 +5497,12 @@
       "version": "16.11.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.39.tgz",
       "integrity": "sha512-K0MsdV42vPwm9L6UwhIxMAOmcvH/1OoVkZyCgEtVu4Wx7sElGloy/W7kMBNe/oJ7V/jW9BVt1F6RahH6e7tPXw==",
+      "dev": true
+    },
+    "@types/semver": {
+      "version": "7.3.12",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
+      "integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
       "dev": true
     },
     "@types/vscode": {

--- a/package.json
+++ b/package.json
@@ -616,6 +616,7 @@
     "@types/glob": "^7.2.0",
     "@types/mocha": "^9.1.0",
     "@types/node": "^16.11.39",
+    "@types/semver": "^7.3.12",
     "@types/vscode": "^1.63.0",
     "@types/which": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^5.33.1",
@@ -645,6 +646,7 @@
   "dependencies": {
     "fast-glob": "^3.2.11",
     "glob": "^8.0.3",
+    "semver": "^7.3.7",
     "vscode-languageclient": "^8.0.2",
     "which": "^2.0.2"
   }

--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -71,8 +71,12 @@ export class LinterSettings {
       this.logger.error(`[lint] Could not spawn ${compiler} to check version.`);
       return;
     }
+    // State the variables explicitly bc the TypeScript compiler on the CI
+    // seemed to optimise away the stdout and regex would return null
     const regex = /^GNU Fortran \([\w.-]+\) (?<version>.*)$/gm;
-    const version = regex.exec(child.stdout.toString().trim()).groups['version'];
+    const output = child.stdout.toString();
+    const match = regex.exec(output);
+    const version = match ? match.groups.version : undefined;
     if (semver.valid(version)) {
       this.version = version;
       this.logger.info(`[lint] Found GNU Fortran version ${version}`);

--- a/test/linter-provider.test.ts
+++ b/test/linter-provider.test.ts
@@ -345,6 +345,131 @@ Error: Missing actual argument for argument 'a' at (1)
     deepStrictEqual(matches, ref);
   });
 });
+suite('GNU (gfortran v11+) lint single plain output', () => {
+  const linter = new FortranLintingProvider();
+  linter['compiler'] = 'gfortran';
+  linter['settings']['modernGNU'] = true;
+  const msg = `err-mod.f90:3:17: Error: (1)`;
+  suite('REGEX matches', () => {
+    const regex = linter['getCompilerREGEX'](linter['compiler']);
+    const matches = [...msg.matchAll(regex)];
+    const g = matches[0].groups;
+    test('REGEX: filename', () => {
+      strictEqual(g?.['fname'], 'err-mod.f90');
+    });
+    test('REGEX: line number', () => {
+      strictEqual(g?.['ln'], '3');
+    });
+    test('REGEX: column number', () => {
+      strictEqual(g?.['cn'], '17');
+    });
+    test('REGEX: severity <sev>', () => {
+      strictEqual(g?.['sev'], 'Error');
+    });
+    test('REGEX: message <msg>', () => {
+      strictEqual(g?.['msg'], '(1)');
+    });
+  });
+  test('Diagnostics Array', () => {
+    const matches = linter['parseLinterOutput'](msg);
+    const ref = [
+      new Diagnostic(
+        new Range(new Position(2, 17), new Position(2, 17)),
+        '(1)',
+        DiagnosticSeverity.Error
+      ),
+    ];
+    deepStrictEqual(matches, ref);
+  });
+});
+suite('GNU (gfortran v11+) lint multiple plain output', () => {
+  const linter = new FortranLintingProvider();
+  linter['compiler'] = 'gfortran';
+  linter['settings']['modernGNU'] = true;
+  const msg = `
+err-mod.f90:3:17: Error: (1)
+err-mod.f90:2:11: Error: IMPLICIT NONE statement at (1) cannot follow PRIVATE statement at (2)
+err-mod.f90:10:22: Error: Missing actual argument for argument ‘arg1’ at (1)`;
+  suite('REGEX matches', () => {
+    const regex = linter['getCompilerREGEX'](linter['compiler']);
+    const matches = [...msg.matchAll(regex)];
+    const g = matches[0].groups;
+    test('REGEX: filename', () => {
+      strictEqual(g?.['fname'], 'err-mod.f90');
+    });
+    test('REGEX: line number', () => {
+      strictEqual(g?.['ln'], '3');
+    });
+    test('REGEX: column number', () => {
+      strictEqual(g?.['cn'], '17');
+    });
+    test('REGEX: severity <sev>', () => {
+      strictEqual(g?.['sev'], 'Error');
+    });
+    test('REGEX: message <msg>', () => {
+      strictEqual(g?.['msg'], '(1)');
+    });
+
+    const g2 = matches[1].groups;
+    test('REGEX: filename', () => {
+      strictEqual(g2?.['fname'], 'err-mod.f90');
+    });
+    test('REGEX: line number', () => {
+      strictEqual(g2?.['ln'], '2');
+    });
+    test('REGEX: column number', () => {
+      strictEqual(g2?.['cn'], '11');
+    });
+    test('REGEX: severity <sev>', () => {
+      strictEqual(g2?.['sev'], 'Error');
+    });
+    test('REGEX: message <msg>', () => {
+      strictEqual(
+        g2?.['msg'],
+        'IMPLICIT NONE statement at (1) cannot follow PRIVATE statement at (2)'
+      );
+    });
+
+    const g3 = matches[2].groups;
+    test('REGEX: filename', () => {
+      strictEqual(g3?.['fname'], 'err-mod.f90');
+    });
+    test('REGEX: line number', () => {
+      strictEqual(g3?.['ln'], '10');
+    });
+    test('REGEX: column number', () => {
+      strictEqual(g3?.['cn'], '22');
+    });
+    test('REGEX: severity <sev>', () => {
+      strictEqual(g3?.['sev'], 'Error');
+    });
+    test('REGEX: message <msg>', () => {
+      strictEqual(g3?.['msg'], 'Missing actual argument for argument ‘arg1’ at (1)');
+    });
+  });
+
+  test('Diagnostics Array', () => {
+    const matches = linter['parseLinterOutput'](msg);
+    const ref = [
+      new Diagnostic(
+        new Range(new Position(2, 17), new Position(2, 17)),
+        '(1)',
+        DiagnosticSeverity.Error
+      ),
+      new Diagnostic(
+        new Range(new Position(1, 11), new Position(1, 11)),
+        'IMPLICIT NONE statement at (1) cannot follow PRIVATE statement at (2)',
+        DiagnosticSeverity.Error
+      ),
+      new Diagnostic(
+        new Range(new Position(9, 22), new Position(9, 22)),
+        'Missing actual argument for argument ‘arg1’ at (1)',
+        DiagnosticSeverity.Error
+      ),
+    ];
+    deepStrictEqual(matches, ref);
+  });
+});
 
 // -----------------------------------------------------------------------------
 

--- a/test/linter-provider.test.ts
+++ b/test/linter-provider.test.ts
@@ -122,6 +122,7 @@ suite('fypp Linter integration', () => {
 suite('GNU (gfortran) lint single', () => {
   const linter = new FortranLintingProvider();
   linter['compiler'] = 'gfortran';
+  linter['settings']['modernGNU'] = false;
   const msg = `
 C:\\Some\\random\\path\\sample.f90:4:18:
 
@@ -164,6 +165,7 @@ Error: Missing actual argument for argument ‘a’ at (1)
 suite('GNU (gfortran) lint multiple', () => {
   const linter = new FortranLintingProvider();
   linter['compiler'] = 'gfortran';
+  linter['settings']['modernGNU'] = false;
   const msg = `
 /fetch/main/FETCH.F90:1629:24:
 
@@ -236,6 +238,7 @@ f951: some warnings being treated as errors
 suite('GNU (gfortran) lint preprocessor', () => {
   const linter = new FortranLintingProvider();
   linter['compiler'] = 'gfortran';
+  linter['settings']['modernGNU'] = false;
   const msg = `
 gfortran: fatal error: cannot execute '/usr/lib/gcc/x86_64-linux-gnu/9/f951': execv: Argument list too long\ncompilation terminated.
 `;
@@ -277,6 +280,7 @@ gfortran: fatal error: cannot execute '/usr/lib/gcc/x86_64-linux-gnu/9/f951': ex
 suite('GNU (gfortran) lint preprocessor multiple', () => {
   const linter = new FortranLintingProvider();
   linter['compiler'] = 'gfortran';
+  linter['settings']['modernGNU'] = false;
   const msg = `
 f951: Warning: Nonexistent include directory '/Code/TypeScript/vscode-fortran-support/test/fortran/include' [-Wmissing-include-dirs]
 /Code/TypeScript/vscode-fortran-support/test/fortran/sample.f90:4:18:


### PR DESCRIPTION
Fixes #523

Adds the option to detect the gfortran version and deploy
the more advanced diagnostic option -fdiagnostic-plain-output
instead of parsing the actual compiler messages which can be
problematic due to the various edge cases