### PR TITLE
feat: initialise linter for projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added support for storing build artefacts in a separate cache directory
+  ([#614](https://github.com/fortran-lang/vscode-fortran-support/issues/614))
+- Added a naive initialization for Fortran source files present in the workspace.
+  The implementation cannot deduce build order so it can partially work
+  ([#680](https://github.com/fortran-lang/vscode-fortran-support/issues/680))
 - Added User Interface tests for program installation
 - Added option to disable Release Notes from being displayed
   ([#675](https://github.com/fortran-lang/vscode-fortran-support/issues/675))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added new settings for disabling Linter initialization and display of initialization Diagnostics
+  `fortran.linter.initialize` and `fortran.experimental.keepInitDiagnostics`
+- Added commands for Initializing, Cleaning build artefacts and Clearing the Diagnostics from the Linter
 - Added support for storing build artefacts in a separate cache directory
   ([#614](https://github.com/fortran-lang/vscode-fortran-support/issues/614))
 - Added a naive initialization for Fortran source files present in the workspace.
@@ -43,6 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Changed the activation events of the extension to include the `onCommand` for all register commands
 - Changed glob resolution module to `glob` from `fast-glob` due to bug #43
   ([#681](https://github.com/fortran-lang/vscode-fortran-support/issues/681))
 - Changed how Python packages are installed for unittesting for performance

--- a/package.json
+++ b/package.json
@@ -52,7 +52,15 @@
   },
   "activationEvents": [
     "onLanguage:FortranFreeForm",
-    "onLanguage:FortranFixedForm"
+    "onLanguage:FortranFixedForm",
+    "onCommand:fortran.analysis.restartLanguageServer",
+    "onCommand:fortran.analysis.rescanLinter",
+    "onCommand:fortran.analysis.cleanLinterDiagnostics",
+    "onCommand:fortran.analysis.cleanLinterFiles",
+    "onCommand:fortran.analysis.initLinter",
+    "onCommand:fortran.analysis.showWhatsNew",
+    "onCommand:fortran.build.run",
+    "onCommand:fortran.build.debug"
   ],
   "main": "./dist/extension.js",
   "extensionDependencies": [
@@ -231,6 +239,12 @@
             "markdownDescription": "Compiler used for linting support.",
             "order": 0
           },
+          "fortran.linter.initialize": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Attempt to initialize the linter by mock-compiling all files in the workspace.",
+            "order": 5
+          },
           "fortran.linter.compilerPath": {
             "type": "string",
             "default": "",
@@ -257,7 +271,7 @@
           "fortran.linter.modOutput": {
             "type": "string",
             "default": "",
-            "markdownDescription": "Global output directory for .mod files generated due to linting `-J<linter.modOutput>`. Can resolve internal variables with `~`, `${workspaceFolder}`, `${env}`, `${config}`, `${file}`, `${fileDirname}`, `${fileBasenameNoExtension}`.",
+            "markdownDescription": "Output directory for .mod files generated due to linting `-J<linter.modOutput>`. By default this is an internal VS Code path unique to each workspace. Can resolve internal variables with `~`, `${workspaceFolder}`, `${env}`, `${config}`, `${file}`, `${fileDirname}`, `${fileBasenameNoExtension}`.",
             "order": 40
           },
           "fortran.linter.fypp.enabled": {
@@ -307,7 +321,7 @@
               "std",
               "gfortran5"
             ],
-            "markdownDescription": "ine numbering marker format,  currently std`, `cpp` and `gfortran5` are supported, where `std` emits `#line` pragmas similar to standard tools, 'cpp' produces line directives as emitted by GNU cpp, and `gfortran5` cpp line directives with a workaround for a bug introduced in GFortran 5. Default: `cpp`.",
+            "markdownDescription": "Line numbering marker format,  currently std`, `cpp` and `gfortran5` are supported, where `std` emits `#line` pragmas similar to standard tools, 'cpp' produces line directives as emitted by GNU cpp, and `gfortran5` cpp line directives with a workaround for a bug introduced in GFortran 5. Default: `cpp`.",
             "order": 120
           },
           "fortran.linter.fypp.extraArgs": {
@@ -527,6 +541,19 @@
         }
       },
       {
+        "id": "experimental",
+        "title": "Experimental",
+        "order": 500,
+        "properties": {
+          "fortran.experimental.keepInitDiagnostics": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Keep (and show) all diagnostics generated from the initialization of the Linter, not just from opened files.",
+            "order": 0
+          }
+        }
+      },
+      {
         "id": "deprecated",
         "title": "Deprecated Options",
         "order": 999,
@@ -581,7 +608,22 @@
       {
         "category": "Fortran",
         "command": "fortran.analysis.rescanLinter",
-        "title": "Rescan Linter paths"
+        "title": "Rescan Linter Include paths"
+      },
+      {
+        "category": "Fortran",
+        "command": "fortran.analysis.initLinter",
+        "title": "Initialize Fortran Linter"
+      },
+      {
+        "category": "Fortran",
+        "command": "fortran.analysis.cleanLinterFiles",
+        "title": "Clean Linter generated files"
+      },
+      {
+        "category": "Fortran",
+        "command": "fortran.analysis.cleanLinterDiagnostics",
+        "title": "Clean All Linter Diagnostics"
       },
       {
         "category": "Fortran",
@@ -613,6 +655,24 @@
           "category": "Fortran",
           "command": "fortran.analysis.rescanLinter",
           "title": "Rescan Linter paths",
+          "when": "!virtualWorkspace && shellExecutionSupported"
+        },
+        {
+          "category": "Fortran",
+          "command": "fortran.analysis.initLinter",
+          "title": "Initialize Fortran Linter",
+          "when": "!virtualWorkspace && shellExecutionSupported"
+        },
+        {
+          "category": "Fortran",
+          "command": "fortran.analysis.cleanLinterFiles",
+          "title": "Clean Linter generated files",
+          "when": "!virtualWorkspace && shellExecutionSupported"
+        },
+        {
+          "category": "Fortran",
+          "command": "fortran.analysis.cleanLinterDiagnostics",
+          "title": "Clean All Linter Diagnostics",
           "when": "!virtualWorkspace && shellExecutionSupported"
         },
         {

--- a/package.json
+++ b/package.json
@@ -722,7 +722,7 @@
     "webpack": "webpack --mode production",
     "pretest": "npm run compile-dev && tsc -p tsconfig.test.json",
     "test": "npm run test:unit && npm run test:integration && npm run test:ui",
-    "test:ui": "extest setup-and-run -i out/test/ui/*.js -m test/ui/.mocharc.js",
+    "test:ui": "extest setup-and-run -i out/test/ui/*.js -m test/ui/.mocharc.js -s .vscode-test -e .vscode-test/extensions",
     "test:unit": "node ./out/test/unitTest/runTest.js",
     "test:integration": "node ./out/test/integration/runTest.js",
     "test:grammar-free": "vscode-tmgrammar-snap -s source.fortran.free -g ./syntaxes/fortran_free-form.tmLanguage.json \"./test/fortran/syntax/**/*{.f90,F90}\"",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,8 @@ export async function activate(context: vscode.ExtensionContext) {
     })
   );
   // Linter is always activated but will only lint if compiler !== Disabled
-  const linter = new FortranLintingProvider(logger, context.storageUri.fsPath);
+  const linterCache = path.join(context.storageUri.fsPath);
+  const linter = new FortranLintingProvider(logger, linterCache);
   linter.activate(context);
   vscode.languages.registerCodeActionsProvider(FortranDocumentSelector(), linter);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,7 +49,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Linter is always activated but will only lint if compiler !== Disabled
   const linterCache = path.join(context.storageUri.fsPath);
   const linter = new FortranLintingProvider(logger, linterCache);
-  linter.activate(context);
+  context.subscriptions.push(...(await linter.activate()));
   vscode.languages.registerCodeActionsProvider(FortranDocumentSelector(), linter);
 
   if (formatterType !== 'Disabled') {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,7 +48,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
   // Linter is always activated but will only lint if compiler !== Disabled
   const linter = new FortranLintingProvider(logger);
-  linter.activate(context.subscriptions);
+  linter.activate(context);
   vscode.languages.registerCodeActionsProvider(FortranDocumentSelector(), linter);
 
   if (formatterType !== 'Disabled') {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,7 @@ export async function activate(context: vscode.ExtensionContext) {
     })
   );
   // Linter is always activated but will only lint if compiler !== Disabled
-  const linter = new FortranLintingProvider(logger);
+  const linter = new FortranLintingProvider(logger, context.storageUri.fsPath);
   linter.activate(context);
   vscode.languages.registerCodeActionsProvider(FortranDocumentSelector(), linter);
 

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -4,6 +4,9 @@
 
 export const RestartLS = 'fortran.analysis.restartLanguageServer';
 export const RescanLint = 'fortran.analysis.rescanLinter';
+export const CleanLintDiagnostics = 'fortran.analysis.cleanLinterDiagnostics';
+export const CleanLintFiles = 'fortran.analysis.cleanLinterFiles';
+export const InitLint = 'fortran.analysis.initLinter';
 export const WhatsNew = 'fortran.analysis.showWhatsNew';
 export const BuildRun = 'fortran.build.run';
 export const BuildDebug = 'fortran.build.debug';

--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -426,6 +426,7 @@ export class FortranLintingProvider {
     const modFlag = this.linter.modFlag;
     // Return the workspaces cache directory if the user has not set a custom path
     if (modout === '') modout = this.storageUI;
+    if (!modout) return [];
 
     modout = resolveVariables(modout);
     this.logger.debug(`[lint] moduleOutput: ${modFlag} ${modout}`);

--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -248,27 +248,6 @@ export class FortranLintingProvider {
   }
 
   /**
-   * Lint a document using the specified linter options
-   * @param document TextDocument to lint
-   * @returns An array of vscode.Diagnostic[]
-   */
-  private async doLint(document: vscode.TextDocument): Promise<vscode.Diagnostic[]> | undefined {
-    // Only lint if a compiler is specified
-    if (!this.settings.enabled) return;
-    // Only lint Fortran (free, fixed) format files
-    if (!isFortran(document)) return;
-
-    const output = await this.doBuild(document);
-    if (!output) return;
-
-    let diagnostics: vscode.Diagnostic[] = this.linter.parse(output);
-    // Remove duplicates from the diagnostics array
-    diagnostics = [...new Map(diagnostics.map(v => [JSON.stringify(v), v])).values()];
-    this.fortranDiagnostics.set(document.uri, diagnostics);
-    return diagnostics;
-  }
-
-  /**
    * Scan the workspace for Fortran files and lint them
    */
   private async initialize() {
@@ -336,6 +315,27 @@ export class FortranLintingProvider {
     files.forEach(file => {
       fs.promises.rm(file);
     });
+  }
+
+  /**
+   * Lint a document using the specified linter options
+   * @param document TextDocument to lint
+   * @returns An array of vscode.Diagnostic[]
+   */
+  private async doLint(document: vscode.TextDocument): Promise<vscode.Diagnostic[]> | undefined {
+    // Only lint if a compiler is specified
+    if (!this.settings.enabled) return;
+    // Only lint Fortran (free, fixed) format files
+    if (!isFortran(document)) return;
+
+    const output = await this.doBuild(document);
+    if (!output) return;
+
+    let diagnostics: vscode.Diagnostic[] = this.linter.parse(output);
+    // Remove duplicates from the diagnostics array
+    diagnostics = [...new Map(diagnostics.map(v => [JSON.stringify(v), v])).values()];
+    this.fortranDiagnostics.set(document.uri, diagnostics);
+    return diagnostics;
   }
 
   private async doBuild(document: vscode.TextDocument): Promise<string> | undefined {

--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -473,7 +473,7 @@ export class FortranLintingProvider {
     if (!which.sync(fypp, { nothrow: true })) {
       this.logger.warn(`[lint] fypp not detected in your system. Attempting to install now.`);
       const msg = `Installing fypp through pip with --user option`;
-      promptForMissingTool('fypp', msg, 'Python', ['Install']);
+      await promptForMissingTool('fypp', msg, 'Python', ['Install']);
     }
     const args: string[] = ['--line-numbering'];
 

--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -241,8 +241,10 @@ export class FortranLintingProvider {
 
   public dispose(): void {
     this.fortranDiagnostics.clear();
-    this.fortranDiagnostics.dispose();
+    // this.fortranDiagnostics.dispose();
     this.subscriptions.forEach(d => d.dispose());
+    // Empty the array after each subscription has been disposed
+    this.subscriptions = [];
   }
 
   /**

--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -423,10 +423,9 @@ export class FortranLintingProvider {
 
   private get modOutputDir(): string[] {
     let modout: string = this.settings.modOutput;
-    // let modFlag = '';
-    // Return if no mod output directory is specified
-    if (modout === '') return [];
     const modFlag = this.linter.modFlag;
+    // Return the workspaces cache directory if the user has not set a custom path
+    if (modout === '') modout = this.storageUI;
 
     modout = resolveVariables(modout);
     this.logger.debug(`[lint] moduleOutput: ${modFlag} ${modout}`);

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -275,6 +275,7 @@ export function resolveVariables(
  * @returns absolute path relative to the workspace root
  */
 export function pathRelToAbs(relPath: string, uri: vscode.Uri): string | undefined {
+  if (path.isAbsolute(relPath)) return relPath;
   const root = getOuterMostWorkspaceFolder(vscode.workspace.getWorkspaceFolder(uri));
   if (root === undefined) return undefined;
   return path.join(root.uri.fsPath, relPath);

--- a/test/integration/linter.test.ts
+++ b/test/integration/linter.test.ts
@@ -1,0 +1,47 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { strictEqual } from 'assert';
+import { FortranLintingProvider } from '../../src/features/linter-provider';
+import {
+  CleanLintDiagnostics,
+  CleanLintFiles,
+  InitLint,
+  RescanLint,
+} from '../../src/features/commands';
+
+suite('Linter', async () => {
+  let doc: vscode.TextDocument;
+  const fileUri = vscode.Uri.file(path.resolve(__dirname, '../../../test/fortran/sample.f90'));
+  const linter = new FortranLintingProvider();
+
+  suiteSetup(async () => {
+    doc = await vscode.workspace.openTextDocument(fileUri);
+    await vscode.window.showTextDocument(doc);
+  });
+
+  test('Check disposables array has been populated', async () => {
+    await linter.activate();
+    strictEqual(linter['subscriptions'].length > 1, true);
+  });
+
+  // test(`Run command ${InitLint}`, async () => {
+  //   await vscode.commands.executeCommand(InitLint);
+  // });
+
+  test(`Run command is ${RescanLint}`, async () => {
+    await vscode.commands.executeCommand(RescanLint);
+  });
+
+  test(`Run command ${CleanLintDiagnostics}`, async () => {
+    await vscode.commands.executeCommand(CleanLintDiagnostics);
+  });
+
+  test(`Run command ${CleanLintFiles}`, async () => {
+    await vscode.commands.executeCommand(CleanLintFiles);
+  });
+
+  test('Check disposables have been cleared', () => {
+    linter.dispose();
+    strictEqual(linter['subscriptions'].length, 0);
+  });
+});

--- a/test/integration/runTest.ts
+++ b/test/integration/runTest.ts
@@ -1,6 +1,10 @@
 import * as path from 'path';
 
-import { runTests } from '@vscode/test-electron';
+import {
+  runTests,
+  downloadAndUnzipVSCode,
+  resolveCliArgsFromVSCodeExecutablePath,
+} from '@vscode/test-electron';
 import { spawnSync } from 'child_process';
 
 async function main() {
@@ -25,15 +29,22 @@ async function main() {
     // Passed to `--extensionDevelopmentPath`
     const extensionDevelopmentPath = path.resolve(__dirname, '../../../');
     const workspacePath = path.resolve(__dirname, '../../../test/fortran/');
+    // Install the C++ extension
+    const vscodeExecutablePath = await downloadAndUnzipVSCode('stable');
+    const [cli, ...args] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
+    spawnSync(cli, [...args, '--install-extension', 'ms-vscode.cpptools'], {
+      encoding: 'utf-8',
+      stdio: 'inherit',
+    });
 
     // The path to the extension test runner script
     // Passed to --extensionTestsPath
     const extensionTestsPath = path.resolve(__dirname, './index');
 
-    const launchArgs = [workspacePath, '--disable-extensions'];
+    const launchArgs = [workspacePath];
     // Download VS Code, unzip it and run the integration test
     await runTests({
-      launchArgs,
+      launchArgs: launchArgs,
       extensionDevelopmentPath,
       extensionTestsPath,
     });

--- a/test/integration/runTest.ts
+++ b/test/integration/runTest.ts
@@ -30,18 +30,18 @@ async function main() {
     const extensionDevelopmentPath = path.resolve(__dirname, '../../../');
     const workspacePath = path.resolve(__dirname, '../../../test/fortran/');
     // Install the C++ extension
-    const vscodeExecutablePath = await downloadAndUnzipVSCode('stable');
-    const [cli, ...args] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
-    spawnSync(cli, [...args, '--install-extension', 'ms-vscode.cpptools'], {
-      encoding: 'utf-8',
-      stdio: 'inherit',
-    });
+    // const vscodeExecutablePath = await downloadAndUnzipVSCode('stable');
+    // const [cli, ...args] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
+    // spawnSync(cli, [...args, '--install-extension', 'ms-vscode.cpptools'], {
+    //   encoding: 'utf-8',
+    //   stdio: 'inherit',
+    // });
 
     // The path to the extension test runner script
     // Passed to --extensionTestsPath
     const extensionTestsPath = path.resolve(__dirname, './index');
 
-    const launchArgs = [workspacePath];
+    const launchArgs = [workspacePath, '--disable-extensions'];
     // Download VS Code, unzip it and run the integration test
     await runTests({
       launchArgs: launchArgs,

--- a/test/unitTest/tools.test.ts
+++ b/test/unitTest/tools.test.ts
@@ -54,8 +54,13 @@ suite('Tools tests', () => {
   test('Resolve local paths: undefined', () => {
     const root = Uri.parse('/home/user/project');
     const absPath = pathRelToAbs('./sample.f90', root);
-    console.log(absPath, root);
     assert.strictEqual(absPath, undefined);
+  });
+
+  test('Resolve local paths: absolute', () => {
+    const root = Uri.parse('/home/user/project');
+    const absPath = pathRelToAbs(path.resolve(process.cwd()), root);
+    assert.strictEqual(absPath, path.resolve(process.cwd()));
   });
 
   test('Resolve local paths: workspace selection', () => {


### PR DESCRIPTION
An early on attempt to generate the linter (sub)module files in a project if existing binaries are not present.

- [x] Progress bar notification
- [x] ~~Parse use trees and 'build' cascade dependencies~~

Fixes #680
Fixes #614