### PR TITLE
Nightly ci if-publish conditino

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Get version
         id: version
-        if: ${{ steps.deploy-nightly.outputs.MAIN-SHA != steps.deploy-nightly.outputs.NIGHTLY-SHA }}
+        if: 'steps.deploy-nightly.outputs.MAIN-SHA != steps.deploy-nightly.outputs.NIGHTLY-SHA'
         run: |
           datetime=$(date +%Y%m%d%H)
           pkg_version=$(node -p "require('./package.json').version")
@@ -32,7 +32,7 @@ jobs:
           echo "::set-output name=VERSION::$version"
 
       - name: Publish Nightly Release
-        if: ${{ steps.deploy-nightly.outputs.MAIN-SHA != steps.deploy-nightly.outputs.NIGHTLY-SHA }}
+        if: 'steps.deploy-nightly.outputs.MAIN-SHA != steps.deploy-nightly.outputs.NIGHTLY-SHA'
         run: |
           echo "Publishing nightly release ${{ steps.version.outputs.VERSION }}"
           npm ci
@@ -42,7 +42,7 @@ jobs:
           VSCE_PAT: ${{ secrets.VS_MARKETPLACE_TOKEN }}
 
       - name: Create Nightly tag
-        if: ${{ steps.deploy-nightly.outputs.MAIN-SHA != steps.deploy-nightly.outputs.NIGHTLY-SHA }}
+        if: 'steps.deploy-nightly.outputs.MAIN-SHA != steps.deploy-nightly.outputs.NIGHTLY-SHA'
         run: |
           # git config user.name github-actions
           # git config user.email 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,7 +37,7 @@ jobs:
           echo "Publishing nightly release ${{ steps.version.outputs.VERSION }}"
           npm ci
           npm i -g vsce
-          vsce publish --pre-release --no-git-tag-version --no-update-package-json ${{ steps.version.outputs.VERSION }}
+          vsce publish --pre-release --no-git-tag-version ${{ steps.version.outputs.VERSION }}
         env:
           VSCE_PAT: ${{ secrets.VS_MARKETPLACE_TOKEN }}
 


### PR DESCRIPTION
Fixes the if-publish condition for the Nightly CI. It used to ignore the condition and it would publish every night regardless of whether any updates were available.

Now we also increment the version in the Nightly release in the package.json