### PR TITLE
look for fortls in the user Scripts folder on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -394,8 +394,8 @@
         "properties": {
           "fortran.fortls.path": {
             "type": "string",
-            "default": "fortls",
-            "markdownDescription": "Path to the Fortran language server (`fortls`).",
+            "default": "",
+            "markdownDescription": "Path to the Fortran language server (`fortls`) (must be absolute).",
             "order": 10
           },
           "fortran.fortls.configure": {

--- a/src/lsp/client.ts
+++ b/src/lsp/client.ts
@@ -49,6 +49,13 @@ export class FortlsClient {
       // Do not allow activating the LS functionality if no fortls is detected
       const fortlsFound = this.getLSPath();
 
+      const configuredPath = resolveVariables(config.get<string>('fortls.path'));
+      if (configuredPath) {
+        const msg = `Failed to run fortls from user configured path '` + configuredPath + `'`;
+        await window.showErrorMessage(msg);
+        return;
+      }
+
       if (!fortlsFound) {
         const msg = `Forlts wasn't found on your system.
         It is highly recommended to use the fortls to enable IDE features like hover, peeking, GoTos and many more. 
@@ -304,7 +311,8 @@ export class FortlsClient {
     // if there's a user configured path to the executable, check if it's absolute
     if (configuredPath !== '') {
       if (!path.isAbsolute(configuredPath)) {
-        throw Error("The path to fortls (fortls.path) must be absolute.");
+        window.showErrorMessage("The path to fortls (fortran.fortls.path) must be absolute.");
+        return false;
       }
 
       pathsToCheck.push(configuredPath);


### PR DESCRIPTION
Hey there, gnikit,

_-- personal message ;) --_
first off, let me say what a tremendous job you have done with fortls!
The extension is leaps ahead from what it was two years ago. I only managed to update a couple of months ago after you posted to Discourse and I was amazed.
_-- end personal message --_

I hopefully made the extension a bit more usable on Windows, where pip installs fortls in the `%appdata%\Roaming\Python\Python311\Scripts\` folder, which is typically not in PATH, so the extension wouldn't find fortls after installing it.
So the only way to use it would be to enter the path to the above folder to the config or to install fortls with admin privileges.
In any case, automatic installation by the extension or updates weren't possible.

Now the extension also looks for fortls in this folder, so all of that is gone.

Other changes:
- The user configured path to fortls must now be absolute.
  This simplified a lot of things and it doesn't make sense to me to
  have multiple versions of fortls on the system, per workspace.
  Please let me know if this is not OK.
- The fortls.disabled config value now gets stored in the USER settings
  instead of workspace. Similar reasons as above, it seems easier to
  find.
- A check for python presence is performed before running pip.
- On Windows, `python` is used instead of `python3` as this is the standard command name on the platform.
