### PR TITLE
bug: Remove dead links from README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed broken badges and replaced them with shields.io
+  ([[#815](https://github.com/fortran-lang/vscode-fortran-support/issues/815)])
 - Fixed regular expression for parsing version of GFortran in linter
   ([#759](https://github.com/fortran-lang/vscode-fortran-support/issues/759))
 - Fixed bug where diagnostic messages would linger from the previous state

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 <div align="center">
 
-[![Downloads](https://vsmarketplacebadge.apphb.com/downloads-short/fortran-lang.linter-gfortran.svg)](https://marketplace.visualstudio.com/items?itemName=fortran-lang.linter-gfortran)
-[![Installs](https://vsmarketplacebadge.apphb.com/installs-short/fortran-lang.linter-gfortran.svg)](https://marketplace.visualstudio.com/items?itemName=fortran-lang.linter-gfortran)
-[![GitHub Actions](https://github.com/fortran-lang/vscode-fortran-support/actions/workflows/main.yaml/badge.svg)](https://github.com/fortran-lang/vscode-fortran-support/actions)
-[![VS Marketplace](https://vsmarketplacebadge.apphb.com/version-short/fortran-lang.linter-gfortran.svg)](https://marketplace.visualstudio.com/items?itemName=fortran-lang.linter-gfortran)
-[![MIT License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://raw.githubusercontent.com/fortran-lang/vscode-fortran-support/master/LICENSE)
+![Visual Studio Marketplace Downloads](https://img.shields.io/visual-studio-marketplace/d/fortran-lang.linter-gfortran?style=flat-square)
+![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/fortran-lang.linter-gfortran?style=flat-square)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/fortran-lang/vscode-fortran-support/main.yaml?label=CI&style=flat-square)
+![Visual Studio Marketplace Version (including pre-releases)](https://img.shields.io/visual-studio-marketplace/v/fortran-lang.linter-gfortran?color=brightgreen&include_prereleases&style=flat-square)
+![GitHub](https://img.shields.io/github/license/fortran-lang/vscode-fortran-support?color=brightgreen&style=flat-square)
 
 </div>
 


### PR DESCRIPTION
This bug caused the packing utility to fail because the dead
links were marked by Microsoft as unsafe.

Fixes #815