### PR TITLE
fix: linter not swapping fixed/free forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed bug where linter would not use the correct Fortran file association
+  if the extension was part of the default extensions of another Fortran lang ID
+  ([#904](https://github.com/fortran-lang/vscode-fortran-support/issues/904))
 - Fixed linter REGEX for GFortran 4.x.x
   ([#813](https://github.com/fortran-lang/vscode-fortran-support/issues/813))
 - Fixed GFortran version regex to allow for semver + build metadata

--- a/src/features/linter-provider.ts
+++ b/src/features/linter-provider.ts
@@ -465,12 +465,15 @@ export class FortranLintingProvider {
     // const extensionIndex = textDocument.fileName.lastIndexOf('.');
     // const fileNameWithoutExtension = textDocument.fileName.substring(0, extensionIndex);
     const fortranSource: string[] = this.settings.fyppEnabled
-      ? ['-xf95', isFreeForm(textDocument) ? '-ffree-form' : '-ffixed-form', '-']
+      ? ['-xf95', '-']
       : [textDocument.fileName];
 
     const argList = [
       ...args,
       ...this.getIncludeParams(includePaths), // include paths
+      // Explicitly set the type for Fortran in case the user has associated
+      // fixed-form extensions to free-form, or vice versa
+      isFreeForm(textDocument) ? this.linter.freeFlag : this.linter.fixedFlag,
       '-o',
       `${textDocument.fileName}.o`,
       ...fortranSource,

--- a/src/lib/linters.ts
+++ b/src/lib/linters.ts
@@ -35,7 +35,15 @@ abstract class Linter {
     /**
      * Compiler flag used to change the directory output for modules
      */
-    public readonly modFlag?: string
+    public readonly modFlag?: string,
+    /**
+     * Compiler flag used to force free-form compilation
+     */
+    public readonly freeFlag?: string,
+    /**
+     * Compiler flag used to force fixed-form compilation
+     */
+    public readonly fixedFlag?: string
   ) {}
 
   public getSeverityLevel(msg_type: string): vscode.DiagnosticSeverity {
@@ -62,7 +70,9 @@ export class GNULinter extends Linter {
       },
       ['-fsyntax-only', '-cpp'],
       ['-Wall'],
-      '-J'
+      '-J',
+      '-ffree-form',
+      '-ffixed-form'
     );
   }
   /**
@@ -116,7 +126,9 @@ export class GNUModernLinter extends Linter {
       },
       ['-fsyntax-only', '-cpp', '-fdiagnostics-plain-output'],
       ['-Wall'],
-      '-J'
+      '-J',
+      '-ffree-form',
+      '-ffixed-form'
     );
   }
 
@@ -163,7 +175,9 @@ export class IntelLinter extends Linter {
       },
       ['-syntax-only', '-fpp'],
       ['-warn', 'all'],
-      '-module'
+      '-module',
+      '-free',
+      '-fixed'
     );
   }
   /**
@@ -206,7 +220,9 @@ export class NAGLinter extends Linter {
       },
       ['-M', '-quiet'],
       [],
-      '-mdir'
+      '-mdir',
+      '-free',
+      '-fixed'
     );
   }
 
@@ -256,7 +272,9 @@ export class LFortranLinter extends Linter {
       },
       ['--error-format=short'],
       [],
-      '-J'
+      '-J',
+      '',
+      '--fixed-form'
     );
   }
 

--- a/test/fortran/.vscode/settings.json
+++ b/test/fortran/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  "files.associations": {
+    "*.f77": "FortranFreeForm"
+  },
   "fortran.logging.level": "Debug",
   "fortran.linter.includePaths": ["${workspaceFolder}/lint/**"],
   "fortran.linter.fypp.enabled": false,

--- a/test/fortran/lint/fixed-as-free.f77
+++ b/test/fortran/lint/fixed-as-free.f77
@@ -1,0 +1,4 @@
+program fixed_as_free
+    implicit none
+    print*, "This is Free Form"
+end program fixed_as_free

--- a/test/integration/linter.test.ts
+++ b/test/integration/linter.test.ts
@@ -44,4 +44,14 @@ suite('Linter', async () => {
     linter.dispose();
     strictEqual(linter['subscriptions'].length, 0);
   });
+
+  test('Check file association overrides propagate to the linter', async () => {
+    const file = '../../../test/fortran/lint/fixed-as-free.f77';
+    const fileUri = vscode.Uri.file(path.resolve(__dirname, file));
+    doc = await vscode.workspace.openTextDocument(fileUri);
+    await vscode.window.showTextDocument(doc);
+    const res = await linter['doLint'](doc);
+    strictEqual(res !== undefined, true);
+    strictEqual(res?.length, 0);
+  });
 });


### PR DESCRIPTION
The linter previously was unable to lint with the correct
compiler options files that had extensions reserved
by another Fortran language ID.

That meant that file associations overriding the default
ones would take effect on the syntax-highlighting
but not on the generation of diagnostics.

Fixes #904