### PR TITLE
Allow user to overwrite line-length flags for gfortran linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed bug where specifying `-ffree-line-length-X` and `-ffixed-line-length-X`
+  as `linter.extraArgs` would be overridden by the default behaviour of `fortls`
+  ([#925](https://github.com/fortran-lang/vscode-fortran-support/issues/925))
 - Fixed bug where linter would not use the correct Fortran file association
   if the extension was part of the default extensions of another Fortran lang ID
   ([#904](https://github.com/fortran-lang/vscode-fortran-support/issues/904))

--- a/src/lint/provider.ts
+++ b/src/lint/provider.ts
@@ -555,7 +555,9 @@ export class FortranLintingProvider {
     if (this.linter.name === 'gfortran') {
       const ln: number = config.get('fortls.maxLineLength');
       const lnStr: string = ln === -1 ? 'none' : ln.toString();
-      args.push(`-ffree-line-length-${lnStr}`, `-ffixed-line-length-${lnStr}`);
+      // Prepend via `unshift` to make sure user defined flags overwrite
+      // the default ones we provide here.
+      args.unshift(`-ffree-line-length-${lnStr}`, `-ffixed-line-length-${lnStr}`);
     }
     if (args.length > 0) this.logger.debug(`[lint] arguments:`, args);
 


### PR DESCRIPTION
Currently, the code appends `-ffree-line-length-none` and `-ffixed-line-length-none` by default to the argument list when invoking `gfortran` as linter. While it is possible to overwrite the line-length by setting `fortls.maxLineLength`, this does only allow to set the same value for both, free-form as well es fixed-form Fortran code. What I need is to keep the common default values (72 for fixed-form and 132 (or none) for free-form Fortran).

A comment in the code at [src/lint/provider.ts#L554](https://github.com/fortran-lang/vscode-fortran-support/blob/fc0419dd3d2db8dca469891a7d65adac1f1381a3/src/lint/provider.ts#L554) states that it should be possible to overwrite those defaults by setting them explicitly in `extraArgs`, but this does not currently work. The reason is that the default arguments are pushed to the argument list **after** the user provided arguments. Hence the defaults will always overwrite the user provided flags.

The proposed fix here is to put the default arguments **before** the user provided flags. This way, if a user puts `-ffixed-line-length-X` or `-ffree-line-length-X` into `extraArgs`, these will always overwrite the defaults.

If there is any other preferred way to solve this issue, just let me know and I will update the PR. I choose the current approach because it seemed to be the least invasive change and the comment in the code made me feel that this was actually the desired behavior in the first place.