### PR TITLE
Fix prettier on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -742,7 +742,7 @@
     "posttest": "npm run format",
     "lint": "eslint . --ext .ts,.tsx",
     "lint-fix": "npm run lint -- --fix",
-    "format": "prettier --write 'src/**/*.{ts,json}' 'test/**/*.ts' 'syntaxes/**/*.json' 'snippets/**/*.json' './**/*.{md,json,yaml,yml}'",
+    "format": "prettier --write src/**/*.{ts,json} test/**/*.ts syntaxes/**/*.json snippets/**/*.json ./**/*.{md,json,yaml,yml}",
     "prepare": "husky install",
     "pre-commit": "lint-staged",
     "coverage": "c8 --clean npm run test"

--- a/package.json
+++ b/package.json
@@ -742,7 +742,7 @@
     "posttest": "npm run format",
     "lint": "eslint . --ext .ts,.tsx",
     "lint-fix": "npm run lint -- --fix",
-    "format": "prettier --write src/**/*.{ts,json} test/**/*.ts syntaxes/**/*.json snippets/**/*.json ./**/*.{md,json,yaml,yml}",
+    "format": "prettier --write --end-of-line auto src/**/*.{ts,json} test/**/*.ts syntaxes/**/*.json snippets/**/*.json ./**/*.{md,json,yaml,yml}",
     "prepare": "husky install",
     "pre-commit": "lint-staged",
     "coverage": "c8 --clean npm run test"


### PR DESCRIPTION
Hello,

this PR makes it possible to work with the repo on Windows.
There are two changes:
- removed quotation marks around paths in the prettier command
Prettier on Windows just doesn't seem to support them.
- added the [--end-of-line auto](https://prettier.io/docs/en/options.html#end-of-line) argument to prettier.
This makes prettier use whatever line endings it sees in the files it processes and not convert everything to LF.
The reason for this is that git has a configuration option [core.autocrlf](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration) which on Windows automatically converts LF endings to CRLF upon checkout and internally converts them back to LF before commiting (so that everything in the repo stays LF). The default settings on Windows is for this option to be on.
What happens when I try to commit something and the pre-commit hook runs, without the `--end-of-line auto` setting, prettier saves all the source files with LF instead of CRLF and I end up with 200 files that appear as modified in git.
Adding the `--end-of-line auto` solves this and shouldn't change anything for the other OSs.

I'm planning on doing some more work for Windows, but trying to go granual here, unlike last time ;)