### PR TITLE
chore: add .gitattributes file for EOL normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+* eol=lf

--- a/package.json
+++ b/package.json
@@ -742,7 +742,7 @@
     "posttest": "npm run format",
     "lint": "eslint . --ext .ts,.tsx",
     "lint-fix": "npm run lint -- --fix",
-    "format": "prettier --write 'src/**/*.{ts,json}' 'test/**/*.ts' 'syntaxes/**/*.json' 'snippets/**/*.json' './**/*.{md,json,yaml,yml}'",
+    "format": "prettier --write \"src/**/*.{ts,json}\" \"test/**/*.ts\" \"syntaxes/**/*.json\" \"snippets/**/*.json\" \"./**/*.{md,json,yaml,yml}\"",
     "prepare": "husky install",
     "pre-commit": "lint-staged",
     "coverage": "c8 --clean npm run test"


### PR DESCRIPTION
- add `.gitattributes` for non-vscode editors
- replace single with double quotes (and escape them) in the prettier call to be shell-agnostic.