### PR TITLE
tests(ui): adds teardown process for Install tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Linting results can be improved by providing additional options to the compiler.
 You can control the include paths to be used by the linter with the `fortran.linter.includePaths` option.
 
 | ❗️ Important | For the best linting results `linter.includePaths` should match the included paths for your project's compilation. |
-| ------------- | ------------------------------------------------------------------------------------------------------------------ |
+| ------------ | ------------------------------------------------------------------------------------------------------------------ |
 
 ```json
 {
@@ -114,7 +114,7 @@ You can control the include paths to be used by the linter with the `fortran.lin
 ```
 
 | ❗️ Important | If a glob pattern is used only directories matching the pattern will be included |
-| ------------- | -------------------------------------------------------------------------------- |
+| ------------ | -------------------------------------------------------------------------------- |
 
 ### Additional linting options
 

--- a/src/lint/provider.ts
+++ b/src/lint/provider.ts
@@ -166,7 +166,10 @@ export class LinterSettings {
 }
 
 export class FortranLintingProvider {
-  constructor(private logger: Logger = new Logger(), private storageUI: string = undefined) {
+  constructor(
+    private logger: Logger = new Logger(),
+    private storageUI: string = undefined
+  ) {
     // Register the Linter provider
     this.fortranDiagnostics = vscode.languages.createDiagnosticCollection('Fortran');
     this.settings = new LinterSettings(this.logger);

--- a/src/lsp/client.ts
+++ b/src/lsp/client.ts
@@ -26,7 +26,10 @@ import {
 export const clients: Map<string, LanguageClient> = new Map();
 
 export class FortlsClient {
-  constructor(private logger: Logger, private context?: vscode.ExtensionContext) {
+  constructor(
+    private logger: Logger,
+    private context?: vscode.ExtensionContext
+  ) {
     this.logger.debug('[lsp.client] Fortran Language Server -- constructor');
 
     // if context is present

--- a/test/ui/install-prompts.test.ts
+++ b/test/ui/install-prompts.test.ts
@@ -17,6 +17,11 @@ describe('Download dependencies', () => {
     await browser.openResources(`${path.resolve(root, 'main.f90')}`);
   });
 
+  afterEach(async () => {
+    const center = await new Workbench().openNotificationsCenter();
+    await center.clearAllNotifications();
+  });
+
   describe('Download fortls language server', () => {
     it('install via pip', async () => {
       const workbench = new Workbench();


### PR DESCRIPTION
The mocking for UI tests is rather difficult to control.
Notifications pop-up in all sorts of orders. This PR aims to somewhat help with that. We might have to edit how the assertions work to make this more robust.