### PR TITLE
support .fpp suffix for fypp files

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,8 @@
           ".FPP",
           ".pf",
           ".PF",
+          ".fpp",
+          ".FPP",
           ".fypp",
           ".FYPP"
         ],

--- a/test/fortran/.vscode/settings.json
+++ b/test/fortran/.vscode/settings.json
@@ -17,7 +17,7 @@
     "PetscInt": "integer(kind=selected_int_kind(5))"
   },
   "fortran.fortls.preprocessor.directories": ["include", "val"],
-  "fortran.fortls.preprocessor.suffixes": [".fypp", ".f90"],
+  "fortran.fortls.preprocessor.suffixes": [".fpp", ".fypp", ".f90"],
   "fortran.fortls.suffixes": [".FFF", ".F90-2018"],
   "fortran.fortls.directories": ["./**"],
   "fortran.fortls.excludeSuffixes": [".snap"],


### PR DESCRIPTION
Fypp docs seem to use `.fpp` and `.fypp` interchangeably