### PR TITLE
chore(settings): disable linter initialisation

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
           },
           "fortran.linter.initialize": {
             "type": "boolean",
-            "default": true,
+            "default": false,
             "markdownDescription": "Attempt to initialize the linter by mock-compiling all files in the workspace.",
             "order": 5
           },


### PR DESCRIPTION
The failure in coverage is because of the excluded sections