### PR TITLE
Resolve internal variables in formatter arguments

### DIFF
--- a/src/format/provider.ts
+++ b/src/format/provider.ts
@@ -7,12 +7,13 @@ import which from 'which';
 
 import { Logger } from '../services/logging';
 import {
-  FORMATTERS,
   EXTENSION_ID,
-  promptForMissingTool,
+  FORMATTERS,
   getWholeFileRange,
-  spawnAsPromise,
   pathRelToAbs,
+  promptForMissingTool,
+  resolveVariables,
+  spawnAsPromise,
 } from '../util/tools';
 
 export class FortranFormattingProvider implements vscode.DocumentFormattingEditProvider {
@@ -120,7 +121,8 @@ export class FortranFormattingProvider implements vscode.DocumentFormattingEditP
    */
   private getFormatterArgs(): string[] {
     const args: string[] = this.workspace.get(`formatting.${this.formatter}Args`, []);
-    return args;
+    // Resolve internal variables
+    return args.map(arg => resolveVariables(arg));
   }
 
   /**


### PR DESCRIPTION
Currently, VS Code variables like ${workspaceFolder} are not expanded in the arguments provided to the selected formatter. As this functionality is already implemented in this project and applied at several places, it's no effort to apply it to the arguments for the formatter as well.